### PR TITLE
Disable networking on Kevin's computer.

### DIFF
--- a/hosts/desktop/hardware-configuration.nix
+++ b/hosts/desktop/hardware-configuration.nix
@@ -32,7 +32,7 @@
   # (the default) this is the recommended approach. When using systemd-networkd it's
   # still possible to use this option, but it's recommended to use it in conjunction
   # with explicit per-interface declarations with `networking.interfaces.<interface>.useDHCP`.
-  networking.useDHCP = lib.mkDefault true;
+  networking.useDHCP = lib.mkDefault false;
   # networking.interfaces.enp7s0.useDHCP = lib.mkDefault true;
   # networking.interfaces.wlp6s0.useDHCP = lib.mkDefault true;
 


### PR DESCRIPTION
The Internet is overwhelmingly a source of malware, and there's not much good on it anymore anyway. Leading operating systems like TempleOS do not support networking for these reasons. Therefore, remove dependency on it.